### PR TITLE
Remove upper python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/maxmahlke/mcfa.git"
 packages = [{'include' = 'mcfa'}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8"
 numpy = "^1.24.2"
 matplotlib = "^3.7.0"
 tensorflow = "^2.11.0"


### PR DESCRIPTION
Similar to https://github.com/maxmahlke/classy/pull/3, the upper bound didn't seem necessary in a published library that doesn't need to access Python internals.